### PR TITLE
Spectral plot UI changes

### DIFF
--- a/myplots/templates/myplots/target_photometry.html
+++ b/myplots/templates/myplots/target_photometry.html
@@ -2,7 +2,6 @@
 {{ figure|safe }}
 {% endblock %} -->
 
-<h4>Photometry</h4>
 <div id="photometryPlot" class="light-curve">
   {{ plot|safe }}
 </div>

--- a/myplots/templates/myplots/target_spectroscopy.html
+++ b/myplots/templates/myplots/target_spectroscopy.html
@@ -2,7 +2,6 @@
 {{ figure|safe }}
 {% endblock %} -->
 
-<h4>Spectroscopy</h4>
 <div id="spectroscopyPlot" class="light-curve">
   {{ plot|safe }}
 </div>

--- a/myplots/templatetags/myplots_tags.py
+++ b/myplots/templatetags/myplots_tags.py
@@ -54,75 +54,32 @@ def target_spectroscopy(context, target, dataproduct=None, snid_path=None, snid_
     fig.update_yaxes(range=[np.nanpercentile(spectrum.flux.value/scale_factor, 0.1),
                             np.nanpercentile(spectrum.flux.value/scale_factor,99.9)])
 
-    ### tellurics ###
-    # Hinkle et al. 2003 “Infrared Atlas of the Arcturus Spectrum”
-    # Wallace et al. 1996 “An Atlas of the Spectrum of the Solar Photosphere from 296 to 1300 nm”
-    telluric_bands = {
-        #'O2 B-band': (6867, 6884),
-        #'O2 gamma-band': (6280, 6310),
-        'O2 A-band': (7590, 7700),
-        'H2O band1': (7150, 7350),
-        'H2O band2': (8100, 8400),
-        #'H2O band3': (8900, 9800)
-    }
-    # add shaded regions for each telluric band
-    for label, (start, end) in telluric_bands.items():
-        fig.add_vrect(
-            x0=start, x1=end,
-            fillcolor="grey",
-            opacity=0.2,
-            layer="below",
-            line_width=0,
-            annotation_text="⊕",
-            annotation_position="top",
-            annotation_font=dict(size=12, color="black")
-        )
-
-    ### arm joins ###
-    # Inclusion of the 4MOST (low res) spectrograph arm overlap arm regions
-    # Taken from the 4MOST manual : https://www.4most.eu/cms/files/VIS-MAN-4MOST-47110-9800-0001_2_00-4MOST-User-Manual.pdf
-
-    overlap_bands = {
-        'blue-green' : (5240,5540),
-        'green-red': (6910,7210)
-    }
-
-    for label, (start, end) in overlap_bands.items():
-        fig.add_vrect(
-            x0=start, x1=end,
-            fillcolor="brown",
-            opacity=0.2,
-            layer="below",
-            line_width=0,
-            annotation_text="AJ",
-            annotation_position="top",
-            annotation_font=dict(size=12, color="black")
-        )
-
 
     ### templates ###
     if snid_path is not None:
         if snid_index is None:
             try:
                 pysnid_file = snid_path
-                fig = add_snid_templates(pysnid_file,
-                                 spectrum.spectral_axis.value,
-                                 spectrum.flux.value,
-                                 fig,
-                                 n=3
-                                )
+                fig = add_snid_templates(
+                	pysnid_file,
+                    spectrum.spectral_axis.value,
+                    spectrum.flux.value,
+                    fig,
+                    n=3
+                )
             except Exception as exc:
                 print(exc)
                 pass
         elif snid_index is not None:
             try:
                 pysnid_file = snid_path
-                fig = add_snid_select_template(pysnid_file,
-                                         spectrum.spectral_axis.value,
-                                         spectrum.flux.value,
-                                         fig,
-                                         idx=snid_index
-                                         )
+                fig = add_snid_select_template(
+                	pysnid_file,
+                    spectrum.spectral_axis.value,
+                    spectrum.flux.value,
+                    fig,
+                    idx=snid_index
+                )
             except Exception as exc:
                 print(exc)
                 pass
@@ -132,12 +89,13 @@ def target_spectroscopy(context, target, dataproduct=None, snid_path=None, snid_
         try:
             auto_snid = f'{paths[0]}'
             try:
-                fig = add_snid_templates(auto_snid,
-                                spectrum.spectral_axis.value,
-                                spectrum.flux.value/scale_factor,
-                                fig,
-                                n=3
-                                )
+                fig = add_snid_templates(
+                	auto_snid,
+                    spectrum.spectral_axis.value,
+                    spectrum.flux.value/scale_factor,
+                    fig,
+                    n=3
+                )
             except Exception as exc:
                 print(exc)
                 pass
@@ -148,28 +106,30 @@ def target_spectroscopy(context, target, dataproduct=None, snid_path=None, snid_
     if ngsf_path is not None:
         try:
             ngsf_file = ngsf_path
-            fig = add_ngsf_templates(ngsf_file,
-                             spectrum.spectral_axis.value,
-                             spectrum.flux.value/scale_factor,
-                             fig,
-                             n=3
-                             )
+            fig = add_ngsf_templates(
+            	ngsf_file,
+                spectrum.spectral_axis.value,
+                spectrum.flux.value/scale_factor,
+                fig,
+                n=3
+            )
         except Exception as exc:
             return {'target': target, 'plot': f'<p>NGSF failed: {exc}</p>'}
 
-    fig.update_layout(autosize=True,
-                      height=650,
-                      xaxis_title='Observed Wavelength (Å)',
-                      yaxis_title='Flux (erg/s/cm²/Å)',
-                      xaxis = dict(showticklabels=True, ticks='outside', linewidth=2),
-                      yaxis = dict(showticklabels=True, ticks='outside', linewidth=2),
-                      legend_title="Best Matches",
-                      margin=dict(t=150),
-                      legend=dict(orientation="h",yanchor="bottom",y=1.05,xanchor="center",x=0.5,entrywidth=0.5,entrywidthmode="fraction",font=dict(size=14)),
-                      showlegend=True,
-                      font_family="P052",
-                      font_size=16,
-                      )
+    fig.update_layout(
+    	autosize=True,
+        height=650,
+        xaxis_title='Observed Wavelength (Å)',
+        yaxis_title='Flux (erg/s/cm²/Å)',
+        xaxis = dict(showticklabels=True, ticks='outside', linewidth=2),
+    	yaxis = dict(showticklabels=True, ticks='outside', linewidth=2),
+        legend_title="Best Matches",
+        margin=dict(t=150),
+        legend=dict(orientation="h",yanchor="bottom",y=1.05,xanchor="center",x=0.5,entrywidth=0.5,entrywidthmode="fraction",font=dict(size=14)),
+        showlegend=True,
+        font_family="P052",
+        font_size=16
+    )
 
     return {
         'target': target,

--- a/static/tom_common/css/custom.css
+++ b/static/tom_common/css/custom.css
@@ -41,34 +41,39 @@ a:hover {
     margin: 0 auto;   /* Centers the container */
 }
 
+/* Container that holds all the checkbox groups (e.g. common, absorption, transient) */
 .checkbox-container.spectroscopy-only {
-    display: flex;
-    flex-direction: column;  /* Stack groups vertically */
-    gap: 20px;  /* Adds vertical space between the groups */
-    width: 100%;
+	display: flex;
+	flex-direction: column;  /* Stack groups vertically */
+	gap: 20px;               /* Space between the groups */
+	width: 100%;
 }
 
-	.checkbox-group h5 {
-		margin-bottom: 0.25rem; /* tighten gap under heading */
-	}
+/* Tighten the spacing under section headings */
+.checkbox-group h5 {
+	margin-bottom: 0.25rem;
+}
 
-	.checkbox-group .checkbox-grid {
-		margin-top: 0;  /* remove extra gap above the grid */
-	}
+/* Remove top gap between heading and grid */
+.checkbox-group .checkbox-grid {
+	margin-top: 0;
+}
 
-	/* optionally reduce the space between checkboxes inside the grid */
-	.checkbox-group .checkbox-grid label {
-		margin-bottom: 0.25rem;
-	}
-
-    .checkbox-group .checkbox-grid {
+/* Reduce space between individual checkbox rows */
+.checkbox-group .checkbox-grid label {
+	margin-bottom: 0.25rem;
 	display: flex;
-	flex-wrap: wrap;
-	gap: 1rem;   /* reduces space between items */
-    }
+	align-items: center;
+	gap: 0.3em;
+	white-space: nowrap;
+}
 
-
-
+.checkbox-group .checkbox-grid {
+	display: grid;
+	grid-template-columns: repeat(10, 1fr); /* 10 equal columns */
+	gap: 0.2em 0.5em; /* Vertical and horizontal spacing */
+	align-items: start;
+}
 
 .d-none {
     display: none !important;  /* Make sure elements are hidden */

--- a/templates/target_detail.html
+++ b/templates/target_detail.html
@@ -119,21 +119,34 @@ fetch("{% static 'json/line_data.json' %}")
     });
 	
  	// --- Main updateLines function ---
-  function updateLines(z, v) {
+    function updateLines(z, v) {
         const figDiv = getFigDiv();
         if (!figDiv) return;
 
-        // --- Throttle redundant redraws ---
-        if (updateTimeout) clearTimeout(updateTimeout);
-        updateTimeout = setTimeout(() => {
-            updateTimeout = null;
-
-            // --- Build line shapes ---
-            function buildLineShapes() {
-                return Object.entries(lines)
-                    .filter(([id]) => document.getElementById(id)?.checked)
-                    .flatMap(([_, { lines: lineList, color }]) =>
-                        lineList.map(({ x }) => {
+        // --- Build line shapes (per-checkbox -> many lines) ---
+        function buildShapes() {
+            return Object.entries(lines)
+                .filter(([id]) => document.getElementById(id)?.checked)
+                .flatMap(([_, entry]) => {
+                    // older JSON variants used entry.x array; newer use entry.lines array of {x,label}
+                    if (Array.isArray(entry.x)) {
+                        // simple numeric list
+                        return entry.x.map(value => {
+                            const xpos = value * ((1 + z) + (v / 299792.458));
+                            return {
+                                type: "line",
+                                x0: xpos,
+                                x1: xpos,
+                                y0: 0,
+                                y1: 1,
+                                xref: "x",
+                                yref: "paper",
+                                line: { color: entry.color, width: 2 },
+                                layer: "below"
+                            };
+                        });
+                    } else if (Array.isArray(entry.lines)) {
+                        return entry.lines.map(({ x }) => {
                             const xpos = x * ((1 + z) + (v / 299792.458));
                             return {
                                 type: "line",
@@ -143,160 +156,230 @@ fetch("{% static 'json/line_data.json' %}")
                                 y1: 1,
                                 xref: "x",
                                 yref: "paper",
-                                line: { color, width: 2 },
+                                line: { color: entry.color, width: 2 },
                                 layer: "below"
                             };
-                        })
-                    );
+                        });
+                    }
+                    return [];
+                });
+        }
+
+        // --- Build plotly annotations for line labels (matches older working version) ---
+        function buildAnnotations() {
+            return Object.entries(lines)
+                .filter(([id]) => document.getElementById(id)?.checked)
+                .flatMap(([_, entry]) => {
+                    if (Array.isArray(entry.x)) {
+                        return entry.x.map(value => {
+                            const xpos = value * ((1 + z) + (v / 299792.458));
+                            return {
+                                x: xpos,
+                                y: 0.90,
+                                xref: "x",
+                                yref: "paper",
+                                text: `${entry.label} ${value}`,
+                                showarrow: false,
+                                textangle: -90,
+                                font: { color: entry.color, size: 8 },
+                                xanchor: "center",
+                                yanchor: "middle",
+                                bgcolor: "white",
+                                layer: "above",
+                                opacity: 0.95,
+                                cliponaxis: true,
+                                // marker to identify these annotations later:
+                                customdata: ["line_label"]
+                            };
+                        });
+                    } else if (Array.isArray(entry.lines)) {
+                        return entry.lines.map(({ x, label }) => {
+                            const xpos = x * ((1 + z) + (v / 299792.458));
+                            return {
+                                x: xpos,
+                                y: 0.90,
+                                xref: "x",
+                                yref: "paper",
+                                text: `${label}`,
+                                showarrow: false,
+                                textangle: -90,
+                                font: { color: entry.color, size: 8 },
+                                xanchor: "center",
+                                yanchor: "middle",
+                                bgcolor: "white",
+                                layer: "above",
+                                opacity: 0.95,
+                                cliponaxis: true,
+                                customdata: ["line_label"]
+                            };
+                        });
+                    }
+                    return [];
+                });
+        }
+
+        // --- Build overlay rectangles + overlay annotations (observed-frame, independent of z/v) ---
+        function buildOverlays() {
+            const shapes = [];
+            const annots = [];
+
+            if (overlayState.telluric) {
+                const telluricBands = { 'O2 A-band': [7590, 7700], 'H2O band1': [7150,7350], 'H2O band2': [8100,8400] };
+                Object.entries(telluricBands).forEach(([label, [start,end]]) => {
+                    shapes.push({
+                        type: "rect",
+                        x0: start, x1: end,
+                        y0: 0, y1: 1,
+                        xref: "x", yref: "paper",
+                        fillcolor: "grey", opacity: 0.2, layer: "below", line: { width: 0 }
+                    });
+                    annots.push({
+                        x: (start + end) / 2, y: 1.0,
+                        xref: "x", yref: "paper",
+                        text: "⊕", showarrow: false,
+                        font: { size: 12, color: "black" },
+                        xanchor: "center", yanchor: "bottom",
+                        opacity: 0.95
+                    });
+                });
             }
 
-            // --- Build line annotations ---
-            function buildLineAnnotations() {
-              return Object.entries(lines)
-                  .filter(([id]) => document.getElementById(id)?.checked)
-                  .flatMap(([_, { lines: lineList, color }]) =>
-                      lineList.map(({ x, label }) => {
-                          const xpos = x * ((1 + z) + (v / 299792.458));
-                          return {
-                              x: xpos,
-                              y: figDiv.layout.yaxis?.range
-                                  ? figDiv.layout.yaxis.range[1] * 0.8 // position near top of y-axis
-                                  : 0, // fallback
-                              xref: "x",
-                              yref: "y",
-                              text: label,
-                              showarrow: false,
-                              textangle: -90,
-                              font: { color, size: 8 },
-                              xanchor: "center",
-                              yanchor: "bottom",
-                              bgcolor: "white",
-                              borderpad: 1.5,
-                              borderradius: 3,
-                              layer: "above",
-                              opacity: 0.9,
-                              cliponaxis: true,
-                              captureevents: false,
-                              customdata: ["line_label"]
-                          };
-                      })
-                  );
-          }
-
-            // --- Build overlay shapes & annotations ---
-            function buildOverlayShapes() {
-                const shapes = [];
-                const annotations = [];
-
-                // --- Tellurics ---
-                if (overlayState.telluric) {
-                    const bands = { "O2 A-band": [7590, 7700], "H2O band1": [7150, 7350], "H2O band2": [8100, 8400] };
-                    Object.entries(bands).forEach(([label, [start, end]]) => {
-                        shapes.push({
-                            type: "rect",
-                            x0: start, x1: end, y0: 0, y1: 1,
-                            xref: "x", yref: "paper",
-                            fillcolor: "grey", opacity: 0.2, layer: "below", line: { width: 0 }
-                        });
-                        annotations.push({
-                            x: (start + end) / 2,
-                            y: 1.0,
-                            xref: "x", yref: "paper",
-                            text: "⊕", showarrow: false,
-                            font: { color: "black", size: 12 },
-                            layer: "above",
-                            opacity: 0.9,
-                            xanchor: "center",
-                            yanchor: "bottom"
-                        });
+            if (overlayState.armJoin) {
+                const overlapBands = { 'blue-green': [5240,5540], 'green-red': [6910,7210] };
+                Object.entries(overlapBands).forEach(([label, [start,end]]) => {
+                    shapes.push({
+                        type: "rect",
+                        x0: start, x1: end,
+                        y0: 0, y1: 1,
+                        xref: "x", yref: "paper",
+                        fillcolor: "brown", opacity: 0.2, layer: "below", line: { width: 0 }
                     });
-                }
-
-                // --- Arm Joins ---
-                if (overlayState.armJoin) {
-                    const bands = { "blue-green": [5240, 5540], "green-red": [6910, 7210] };
-                    Object.entries(bands).forEach(([label, [start, end]]) => {
-                        shapes.push({
-                            type: "rect",
-                            x0: start, x1: end, y0: 0, y1: 1,
-                            xref: "x", yref: "paper",
-                            fillcolor: "brown", opacity: 0.2, layer: "below", line: { width: 0 }
-                        });
-                        annotations.push({
-                            x: (start + end) / 2, y: 1.00,
-                            xref: "x", yref: "paper",
-                            text: "AJ", showarrow: false,
-                            font: { color: "black", size: 12 },
-                            layer: "above",
-                            opacity: 0.9,
-                            xanchor: "center",
-                            yanchor: "bottom"
-                        });
+                    annots.push({
+                        x: (start + end) / 2, y: 1.0,
+                        xref: "x", yref: "paper",
+                        text: "AJ", showarrow: false,
+                        font: { size: 12, color: "black" },
+                        xanchor: "center", yanchor: "bottom",
+                        opacity: 0.95
                     });
-                }
-
-                // --- Skylines ---
-                if (overlayState.skyline) {
-                    const bands = { "6300": [6290, 6310], "5577": [5575, 5580] };
-                    Object.entries(bands).forEach(([label, [start, end]]) => {
-                        shapes.push({
-                            type: "rect",
-                            x0: start, x1: end, y0: 0, y1: 1,
-                            xref: "x", yref: "paper",
-                            fillcolor: "black", opacity: 0.3, layer: "below", line: { width: 0 }
-                        });
-                        annotations.push({
-                            x: (start + end) / 2, y: 1.0,
-                            xref: "x", yref: "paper",
-                            text: "Sky-Sub", showarrow: false,
-                            font: { color: "black", size: 12 },
-                            layer: "above",
-                            opacity: 0.9,
-                            xanchor: "center",
-                            yanchor: "bottom"
-                        });
-                    });
-                }
-
-                return { shapes, annotations };
+                });
             }
 
-            // --- Apply shapes & annotations ---
-            function applyAll() {
-	const { shapes: overlayShapes, annotations: overlayAnnots } = buildOverlayShapes();
-	const lineShapes = buildLineShapes();
-	const lineAnnots = buildLineAnnotations();
+            if (overlayState.skyline) {
+                const skylineBands = { '6300': [6290,6310], '5577': [5575,5580] };
+                Object.entries(skylineBands).forEach(([label, [start,end]]) => {
+                    shapes.push({
+                        type: "rect",
+                        x0: start, x1: end,
+                        y0: 0, y1: 1,
+                        xref: "x", yref: "paper",
+                        fillcolor: "black", opacity: 0.3, layer: "below", line: { width: 0 }
+                    });
+                    annots.push({
+                        x: (start + end) / 2, y: 1.0,
+                        xref: "x", yref: "paper",
+                        text: "Sky-Sub", showarrow: false,
+                        font: { size: 12, color: "black" },
+                        xanchor: "center", yanchor: "bottom",
+                        opacity: 0.95
+                    });
+                });
+            }
 
-	// 1️⃣ Temporarily remove all annotations and lines before autoscale
-	const currentXRange = figDiv.layout.xaxis?.range ? [...figDiv.layout.xaxis.range] : null;
-	const currentYRange = figDiv.layout.yaxis?.range ? [...figDiv.layout.yaxis.range] : null;
+            return { shapes, annots };
+        }
 
-	Plotly.relayout(figDiv, {
-		shapes: overlayShapes,         // only background overlays
-		annotations: overlayAnnots,    // overlay annotations only
-		"xaxis.autorange": false,
-		"yaxis.autorange": false,
-		...(currentXRange && { "xaxis.range": currentXRange }),
-		...(currentYRange && { "yaxis.range": currentYRange })
-	}).then(() => {
-		// 2️⃣ Lock the axes in place
-		const lockedX = figDiv.layout.xaxis.range;
-		const lockedY = figDiv.layout.yaxis.range;
+        // --- Apply shapes & annotations with ranges preserved ---
+        async function applyShapesAndAnnotations() {
+            // --- Gather overlays, line shapes, and annotations ---
+            const { shapes: overlayShapes, annots: overlayAnnots } = buildOverlays();
+            const lineShapes = buildShapes();
+            const lineAnnots = buildAnnotations();
 
-		// 3️⃣ Add line shapes + labels, forcing range back to locked state
-		return Plotly.relayout(figDiv, {
-			shapes: overlayShapes.concat(lineShapes),
-			annotations: overlayAnnots.concat(lineAnnots),
-			"xaxis.autorange": false,
-			"yaxis.autorange": false,
-			"xaxis.range": lockedX,
-			"yaxis.range": lockedY
-		});
-	});
-}
+            // --- Ensure shaded regions draw behind traces ---
+            overlayShapes.forEach(s => {
+                if (s.type === "rect") s.layer = "below traces";
+            });
 
-            applyAll();
+            // --- Preserve current view ranges ---
+            const currentX = figDiv.layout.xaxis?.range ? [...figDiv.layout.xaxis.range] : null;
+            const currentY = figDiv.layout.yaxis?.range ? [...figDiv.layout.yaxis.range] : null;
+
+            // --- First relayout: overlays + locked axes (no line annotations yet) ---
+            const relayoutPayload = {
+                shapes: overlayShapes.concat(lineShapes),
+                annotations: overlayAnnots,
+                "xaxis.autorange": false,
+                "yaxis.autorange": false,
+            };
+            if (currentX) relayoutPayload["xaxis.range"] = currentX;
+            if (currentY) relayoutPayload["yaxis.range"] = currentY;
+
+            await Plotly.relayout(figDiv, relayoutPayload);
+
+            // --- Second relayout: add line annotations while preserving shapes ---
+            const mergedAnnots = (figDiv.layout.annotations || []).concat(lineAnnots);
+            const preservedShapes = figDiv.layout.shapes || [];
+
+            await Plotly.relayout(figDiv, {
+                shapes: preservedShapes,
+                annotations: mergedAnnots,
+            });
+
+            // --- Done ---
+            return;
+        }
+
+        // --- Autoscale handler: remove overlays, let Plotly autorange, then reapply overlays/labels ---
+        async function safelyReapplyAfterAutoscale() {
+            // prevent reentry
+            if (figDiv._isRescaling) return;
+            figDiv._isRescaling = true;
+
+            try {
+                // remove lines + annotations (keep only overlay rects if you prefer)
+                await Plotly.relayout(figDiv, { shapes: [], annotations: [] });
+
+                // trigger autorange
+                await Plotly.relayout(figDiv, { "xaxis.autorange": true, "yaxis.autorange": true });
+
+                // lock new ranges
+                const xaxis = figDiv.layout.xaxis;
+                const yaxis = figDiv.layout.yaxis;
+                await Plotly.relayout(figDiv, {
+                    "xaxis.autorange": false,
+                    "yaxis.autorange": false,
+                    "xaxis.range": xaxis.range,
+                    "yaxis.range": yaxis.range
+                });
+
+                // reapply shapes & annotations
+                await applyShapesAndAnnotations();
+            } catch (err) {
+                console.error("safelyReapplyAfterAutoscale error:", err);
+            } finally {
+                figDiv._isRescaling = false;
+            }
+        }
+
+        // --- Initial draw ---
+        // throttle and call
+        if (updateTimeout) clearTimeout(updateTimeout);
+        updateTimeout = setTimeout(() => {
+            updateTimeout = null;
+            applyShapesAndAnnotations();
         }, 1);
+
+        // --- Hook events once ---
+        if (!figDiv._ignoreOverlaysHandlerAdded) {
+            figDiv.on("plotly_doubleclick", () => safelyReapplyAfterAutoscale());
+            figDiv.on("plotly_relayout", ev => {
+                if (ev["xaxis.autorange"] === true || ev["yaxis.autorange"] === true || ev["scene.autorange"] === true) {
+                    safelyReapplyAfterAutoscale();
+                }
+            });
+            figDiv._ignoreOverlaysHandlerAdded = true;
+        }
     }
 
     // --- Ensure initial draw respects overlays ---

--- a/templates/target_detail.html
+++ b/templates/target_detail.html
@@ -28,7 +28,7 @@ document.addEventListener("DOMContentLoaded", function () {
     }
 
     // Main spectroscopy plot
-    const plotDiv = document.querySelector("#spectroscopyPlot .js-plotly-plot");
+    const figDiv = document.querySelector("#spectroscopyPlot .js-plotly-plot");
 
     // Redshift handling and plot updates.
     const redshiftSlider = document.querySelector("#redshiftSlider");
@@ -86,136 +86,226 @@ fetch("{% static 'json/line_data.json' %}")
 	.catch(error => console.error("Error loading line data:", error));
 
   let updateTimeout = null; // global throttle timer
+  
+	// --- Overlay toggle configuration ---
+    const overlayButtons = [
+        { id: "telluric_display", overlay: "telluric", active: true },
+        { id: "arm_join_display", overlay: "armJoin", active: true },
+        { id: "skyline_display", overlay: "skyline", active: false }
+    ];
+    
+    // Track overlay state
+    const overlayState = {};
+    overlayButtons.forEach(btn => {
+        overlayState[btn.overlay] = btn.active;
 
-  function updateLines(z, v) {
-	  const figDiv = getFigDiv();
+	// Style buttons: green when active, white when off, remove focus outline & highlight
+        const element = document.getElementById(btn.id);
+        if (element) {
+            element.style.backgroundColor = btn.active ? "green" : "white";
+            element.style.color = "black";
+            element.style.border = "1px solid #ccc";
+            element.style.outline = "none";
+            element.style.transition = "background-color 0.2s";
+            element.addEventListener("mousedown", e => e.preventDefault()); // remove blue click highlight
 
-	// --- Throttle redundant redraws ---
-	if (updateTimeout) clearTimeout(updateTimeout);
-	updateTimeout = setTimeout(() => {
-		updateTimeout = null;
-
-		// --- Build line shapes ---
-		function buildShapes() {
-			return Object.entries(lines)
-				.filter(([id]) => document.getElementById(id)?.checked)
-				.flatMap(([_, { lines: lineList, color }]) =>
-					lineList.map(({ x }) => {
-						const xpos = x * ((1 + z) + (v / 299792.458));
-						return {
-							type: "line",
-							x0: xpos,
-							x1: xpos,
-							y0: 0,
-							y1: 1,
-							xref: "x",
-							yref: "paper",
-							line: { color, width: 2 },
-							layer: "below"
-						};
-					})
-				);
-		}
-
-		// --- Build text annotations ---
-		function buildAnnotations() {
-			return Object.entries(lines)
-				.filter(([id]) => document.getElementById(id)?.checked)
-				.flatMap(([_, { lines: lineList, color }]) =>
-					lineList.map(({ x, label }) => {
-						const xpos = x * ((1 + z) + (v / 299792.458));
-						return {
-							x: xpos,
-							y: 0.90,
-							xref: "x",
-							yref: "paper",
-							text: `${label}`,
-							showarrow: false,
-							textangle: -90,
-							font: { color, size: 8 },
-							xanchor: "center",
-							yanchor: "middle",
-							bgcolor: "white",
-							layer: "above",
-							opacity: 0.9,
-							cliponaxis: true,
-                            customdata: ["line_label"]
-						};
-					})
-				);
-		}
-
-		// --- Combine with telluric rectangles (if any) ---
-		function applyShapesAndAnnotations() {
-			const vrects = figDiv.layout.shapes?.filter(s => s.type === "rect") || [];
-			const allShapes = vrects.concat(buildShapes());
-
-			const currentXRange = figDiv.layout.xaxis?.range ? [...figDiv.layout.xaxis.range] : null;
-			const currentYRange = figDiv.layout.yaxis?.range ? [...figDiv.layout.yaxis.range] : null;
-
-			// Preserve existing annotations (e.g., vrect labels)
-            const existingAnnots = figDiv.layout.annotations?.filter(a => !a.customdata?.includes("line_label")) || [];
-            const combinedAnnots = existingAnnots.concat(buildAnnotations());
-
-            Plotly.relayout(figDiv, {
-                shapes: allShapes,
-                annotations: combinedAnnots,
-                "xaxis.autorange": false,
-                "yaxis.autorange": false,
-                ...(currentXRange && { "xaxis.range": currentXRange }),
-                ...(currentYRange && { "yaxis.range": currentYRange })
+            // Toggle on click
+            element.addEventListener("click", () => {
+                overlayState[btn.overlay] = !overlayState[btn.overlay];
+                element.style.backgroundColor = overlayState[btn.overlay] ? "green" : "white";
+                updateLines(Number(redshiftSlider.value), Number(velocitySlider.value));
             });
-		}
+        }
+    });
+	
+ 	// --- Main updateLines function ---
+  function updateLines(z, v) {
+        const figDiv = getFigDiv();
+        if (!figDiv) return;
 
-		// --- Handle autoscale safely ---
-		function safelyReapplyAfterAutoscale() {
-			if (figDiv._isRescaling) return;
-			figDiv._isRescaling = true;
+        // --- Throttle redundant redraws ---
+        if (updateTimeout) clearTimeout(updateTimeout);
+        updateTimeout = setTimeout(() => {
+            updateTimeout = null;
 
-			// Temporarily remove overlays, autorange, then reapply
-			Plotly.relayout(figDiv, { shapes: [], annotations: [] })
-				.then(() =>
-					Plotly.relayout(figDiv, {
-						"xaxis.autorange": true,
-						"yaxis.autorange": true
-					})
-				)
-				.then(() => {
-					const { xaxis, yaxis } = figDiv.layout;
-					return Plotly.relayout(figDiv, {
-						"xaxis.autorange": false,
-						"yaxis.autorange": false,
-						"xaxis.range": xaxis.range,
-						"yaxis.range": yaxis.range
-					});
-				})
-				.then(() => {
-					applyShapesAndAnnotations();
-				})
-				.finally(() => {
-					figDiv._isRescaling = false;
-				});
-		}
+            // --- Build line shapes ---
+            function buildLineShapes() {
+                return Object.entries(lines)
+                    .filter(([id]) => document.getElementById(id)?.checked)
+                    .flatMap(([_, { lines: lineList, color }]) =>
+                        lineList.map(({ x }) => {
+                            const xpos = x * ((1 + z) + (v / 299792.458));
+                            return {
+                                type: "line",
+                                x0: xpos,
+                                x1: xpos,
+                                y0: 0,
+                                y1: 1,
+                                xref: "x",
+                                yref: "paper",
+                                line: { color, width: 2 },
+                                layer: "below"
+                            };
+                        })
+                    );
+            }
 
-		// --- Initial draw ---
-		applyShapesAndAnnotations();
+            // --- Build line annotations ---
+            function buildLineAnnotations() {
+              return Object.entries(lines)
+                  .filter(([id]) => document.getElementById(id)?.checked)
+                  .flatMap(([_, { lines: lineList, color }]) =>
+                      lineList.map(({ x, label }) => {
+                          const xpos = x * ((1 + z) + (v / 299792.458));
+                          return {
+                              x: xpos,
+                              y: figDiv.layout.yaxis?.range
+                                  ? figDiv.layout.yaxis.range[1] * 0.95 // position near top of y-axis
+                                  : 0, // fallback
+                              xref: "x",
+                              yref: "y",
+                              text: label,
+                              showarrow: false,
+                              textangle: -90,
+                              font: { color, size: 8 },
+                              xanchor: "center",
+                              yanchor: "bottom",
+                              bgcolor: "white",
+                              borderpad: 1.5,
+                              borderradius: 3,
+                              layer: "above",
+                              opacity: 0.9,
+                              cliponaxis: true,
+                              captureevents: false,
+                              customdata: ["line_label"]
+                          };
+                      })
+                  );
+          }
 
-		// --- Attach event handlers once ---
-		if (!figDiv._ignoreOverlaysHandlerAdded) {
-			figDiv.on("plotly_doubleclick", safelyReapplyAfterAutoscale);
-			figDiv.on("plotly_relayout", ev => {
-				if (
-					ev["xaxis.autorange"] === true ||
-					ev["yaxis.autorange"] === true ||
-					ev["scene.autorange"] === true
-				) {
-					safelyReapplyAfterAutoscale();
-				}
-			});
-			figDiv._ignoreOverlaysHandlerAdded = true;
-		}
-	}, 1); // <-- redraw throttle (ms)
-  }
+            // --- Build overlay shapes & annotations ---
+            function buildOverlayShapes() {
+                const shapes = [];
+                const annotations = [];
+
+                // --- Tellurics ---
+                if (overlayState.telluric) {
+                    const bands = { "O2 A-band": [7590, 7700], "H2O band1": [7150, 7350], "H2O band2": [8100, 8400] };
+                    Object.entries(bands).forEach(([label, [start, end]]) => {
+                        shapes.push({
+                            type: "rect",
+                            x0: start, x1: end, y0: 0, y1: 1,
+                            xref: "x", yref: "paper",
+                            fillcolor: "grey", opacity: 0.2, layer: "below", line: { width: 0 }
+                        });
+                        annotations.push({
+                            x: (start + end) / 2,
+                            y: 1.0,
+                            xref: "x", yref: "paper",
+                            text: "⊕", showarrow: false,
+                            font: { color: "black", size: 12 },
+                            layer: "above",
+                            opacity: 0.9,
+                            xanchor: "center",
+                            yanchor: "bottom"
+                        });
+                    });
+                }
+
+                // --- Arm Joins ---
+                if (overlayState.armJoin) {
+                    const bands = { "blue-green": [5240, 5540], "green-red": [6910, 7210] };
+                    Object.entries(bands).forEach(([label, [start, end]]) => {
+                        shapes.push({
+                            type: "rect",
+                            x0: start, x1: end, y0: 0, y1: 1,
+                            xref: "x", yref: "paper",
+                            fillcolor: "brown", opacity: 0.2, layer: "below", line: { width: 0 }
+                        });
+                        annotations.push({
+                            x: (start + end) / 2, y: 1.00,
+                            xref: "x", yref: "paper",
+                            text: "AJ", showarrow: false,
+                            font: { color: "black", size: 12 },
+                            layer: "above",
+                            opacity: 0.9,
+                            xanchor: "center",
+                            yanchor: "bottom"
+                        });
+                    });
+                }
+
+                // --- Skylines ---
+                if (overlayState.skyline) {
+                    const bands = { "6300": [6290, 6310], "5577": [5575, 5580] };
+                    Object.entries(bands).forEach(([label, [start, end]]) => {
+                        shapes.push({
+                            type: "rect",
+                            x0: start, x1: end, y0: 0, y1: 1,
+                            xref: "x", yref: "paper",
+                            fillcolor: "black", opacity: 0.3, layer: "below", line: { width: 0 }
+                        });
+                        annotations.push({
+                            x: (start + end) / 2, y: 1.0,
+                            xref: "x", yref: "paper",
+                            text: "Sky-Sub", showarrow: false,
+                            font: { color: "black", size: 12 },
+                            layer: "above",
+                            opacity: 0.9,
+                            xanchor: "center",
+                            yanchor: "bottom"
+                        });
+                    });
+                }
+
+                return { shapes, annotations };
+            }
+
+            // --- Apply shapes & annotations ---
+            function applyAll() {
+	const { shapes: overlayShapes, annotations: overlayAnnots } = buildOverlayShapes();
+	const lineShapes = buildLineShapes();
+	const lineAnnots = buildLineAnnotations();
+
+	// 1️⃣ Temporarily remove all annotations and lines before autoscale
+	const currentXRange = figDiv.layout.xaxis?.range ? [...figDiv.layout.xaxis.range] : null;
+	const currentYRange = figDiv.layout.yaxis?.range ? [...figDiv.layout.yaxis.range] : null;
+
+	Plotly.relayout(figDiv, {
+		shapes: overlayShapes,         // only background overlays
+		annotations: overlayAnnots,    // overlay annotations only
+		"xaxis.autorange": false,
+		"yaxis.autorange": false,
+		...(currentXRange && { "xaxis.range": currentXRange }),
+		...(currentYRange && { "yaxis.range": currentYRange })
+	}).then(() => {
+		// 2️⃣ Lock the axes in place
+		const lockedX = figDiv.layout.xaxis.range;
+		const lockedY = figDiv.layout.yaxis.range;
+
+		// 3️⃣ Add line shapes + labels, forcing range back to locked state
+		return Plotly.relayout(figDiv, {
+			shapes: overlayShapes.concat(lineShapes),
+			annotations: overlayAnnots.concat(lineAnnots),
+			"xaxis.autorange": false,
+			"yaxis.autorange": false,
+			"xaxis.range": lockedX,
+			"yaxis.range": lockedY
+		});
+	});
+}
+
+            applyAll();
+        }, 1);
+    }
+
+    // --- Ensure initial draw respects overlays ---
+    const initialFigDiv = getFigDiv();
+    if (initialFigDiv) {
+        initialFigDiv.on("plotly_afterplot", () => {
+            updateLines(Number(redshiftSlider.value), Number(velocitySlider.value));
+        });
+    }
 
     function updateRedshiftVelocity() {
         // Always pull from the current slider values (force numbers)
@@ -586,6 +676,14 @@ fetch("{% static 'json/line_data.json' %}")
       {% endif %}
       <!-- END TAGS -->
 
+      <h3>Download</h3>
+      <div class="mb-2">
+        <a href="{% url 'download_spectrum' target.id %}"
+           class="btn btn-sm btn-outline-secondary">
+          Download spectrum (ASCII)
+        </a>
+      </div>
+
       <h3>Classifications</h3>
       <p>
         <u><strong>Auto Classification:</strong></u>&emsp;
@@ -666,6 +764,7 @@ fetch("{% static 'json/line_data.json' %}")
         <a class="nav-link" id="manage-groups-tab" href="#manage-groups" role="tab" data-toggle="tab">Manage Groups</a>
       </li>-->
     </ul>
+    
     <div class="tab-content">
       <div class="tab-pane" id="observe">
         <h4>Observe</h4>
@@ -681,12 +780,14 @@ fetch("{% static 'json/line_data.json' %}")
           <p>Airmass plotting for non-sidereal targets is not currently supported. If you would like to add this functionality, please check out the <a href="https://github.com/TOMToolkit/tom_nonsidereal_airmass" target="_blank">non-sidereal airmass plugin.</a></p>
         {% endif %}
       </div>
+      
       <div class="tab-pane" id="observations">
         {% existing_observation_form object %}
         <h4>Observations</h4>
         <a href="{% url 'targets:detail' pk=target.id %}?update_status=True" title="Update status of observations for target" class="btn btn-primary">Update Observations Status</a>
         {% observation_list object %}
       </div>
+      
       <div class="tab-pane" id="manage-data">
         {% if user.is_authenticated %}
           {% upload_dataproduct object %}
@@ -698,35 +799,42 @@ fetch("{% static 'json/line_data.json' %}")
         {% endif %}
         {% dataproduct_list_for_target object %}
       </div>
+      
       <div class="tab-pane" id="manage-groups">
         {% target_groups target %}
       </div>
+      
       <div class="tab-pane" id="photometry">
         {% target_photometry target %}
         {% get_photometry_data object %}
-        </div>
+    </div>
+      
       <div class="tab-pane active" id="spectroscopy" data-target-id="{{ target.id }}">
         {% target_spectroscopy target %}
       </div>
-	  <div>
-        <!-- Bin/Overplot controls -->
-        <div class="d-flex align-items-center gap-2 mb-4 spectroscopy-only">
-          <input class="form-check-input" type="checkbox" id="toggle-binned" checked>
-          <label class="form-check-label me-3" for="toggle-binned">Binned (Å): </label>
-            <label for="bin-size"></label><input id="bin-size" class="form-control form-control-sm me-2" style="width:4rem"
-                                                 type="number" min="5" step="10" value="15">
+
+      <div class="d-flex flex-column gap-3 spectroscopy-only">
+
+        <!-- Bin/Overplot + Control buttons aligned as a single row -->
+        <div class="d-flex align-items-center gap-3">
+          <!-- Bin checkbox + input -->
+          <div class="d-flex align-items-center gap-1" style="min-width: 200px;">
+            <input class="form-check-input" type="checkbox" id="toggle-binned" checked>
+            <label class="form-check-label mb-0" for="toggle-binned">Binned (Å):</label>
+            <input id="bin-size" class="form-control form-control-sm" type="number" min="5" step="10" value="15" style="width:4rem;">
+          </div>
+
+          <!-- Spacer between bin input and buttons -->
+          <div style="width:1rem;"></div>
+
+          <!-- Vertical feature buttons -->
+          <button id="telluric_display" class="btn btn-sm toggle-btn">Telluric Regions</button>
+          <button id="arm_join_display" class="btn btn-sm toggle-btn">Arm Joins</button>
+          <button id="skyline_display" class="btn btn-sm toggle-btn">Skylines</button>
         </div>
-        <!-- Bin/Overplot controls -->
 
-      <!-- Download spectrum (ASCII) -->
-      <a href="{% url 'download_spectrum' target.id %}"
-         class="btn btn-sm btn-outline-secondary spectroscopy-only mb-3">
-        Download spectrum (ASCII)
-      </a>
-
-      </div>
-      <!-- Checkboxes -->
-      <div class="checkbox-container spectroscopy-only">
+        <!-- Checkboxes -->
+        <div class="checkbox-container spectroscopy-only">
 
           <div class="checkbox-group">
               <h5>Common Lines</h5>
@@ -743,7 +851,8 @@ fetch("{% static 'json/line_data.json' %}")
               <div class="checkbox-grid" id="transient-specific-lines"></div>
           </div>
 
-    </div>
+        </div>
+      </div>
       
       <!--{% comments_enabled as comments_are_enabled %}
       <hr/>
@@ -773,7 +882,7 @@ fetch("{% static 'json/line_data.json' %}")
           id="redshiftSlider"
           min="0"
           max="3"
-          step="0.0001"
+          step="0.001"
           value="{{ object.auto_tidesclass_z|default_if_none:0 }}"
           style="width: 300px"
       >
@@ -801,7 +910,7 @@ fetch("{% static 'json/line_data.json' %}")
               id="redshiftInput"
               min="0"
               max="3"
-              step="0.0001"
+              step="0.001"
               value="{{ object.auto_tidesclass_z|default_if_none:0 }}"
               style="width: 80px; text-align: center;"
           >

--- a/templates/target_detail.html
+++ b/templates/target_detail.html
@@ -160,7 +160,7 @@ fetch("{% static 'json/line_data.json' %}")
                           return {
                               x: xpos,
                               y: figDiv.layout.yaxis?.range
-                                  ? figDiv.layout.yaxis.range[1] * 0.95 // position near top of y-axis
+                                  ? figDiv.layout.yaxis.range[1] * 0.8 // position near top of y-axis
                                   : 0, // fallback
                               xref: "x",
                               yref: "y",


### PR DESCRIPTION
- Spectral line labels are now fully excluded from plot auto-rescaling
- Addition of marking regions where there is likely to be skyline contamination outside the standard telluric regions
- All vertical regions are now toggle-able
- Redshift selection box now respects click up + click down
- Line labels and lines now respect selected redshift on display
- Download spectrum box now moved to sidebar for space 
- Tidied the spectral line tickbox grid
- Removal of superfluous text titles to save a little space