### PR TITLE
Fixing Lasair-LSST API

### DIFF
--- a/custom_code/templatetags/tides_targets_extras.py
+++ b/custom_code/templatetags/tides_targets_extras.py
@@ -57,7 +57,7 @@ def tides_target_data(target):
     else:
         ztflink = ''
     if lsstname is not None:
-        lsstlink = "https://lasair-lsst.lsst.ac.uk/objects/" + lsstname
+        lsstlink = "https://lasair.lsst.ac.uk/objects/" + lsstname
     else:
         lsstlink = ''
     return {'target': target, 'extras': extras,

--- a/myplots/templatetags/myplots_tags.py
+++ b/myplots/templatetags/myplots_tags.py
@@ -291,7 +291,10 @@ def target_photometry(context, target, dataproduct=None):
             warnings.warn(f"Warning: Lasair API key for {survey.upper()} not set!", UserWarning)
             continue
         try:
-            #phot = fetch_target_lasair(49.1384664, 44.9725084, survey)  # ZTF25aacedrs for testing
+            #if survey == "ztf":
+            #    phot = fetch_target_lasair(49.1384664, 44.9725084, survey)  # ZTF25aacedrs for testing
+            #if survey == "lsst":
+            #    phot = fetch_target_lasair(57.421526, -48.269298, survey)  # 313761042284412983 for testing
             phot = fetch_target_lasair(target.ra, target.dec, survey)
             photometry_list.append(phot)
         except Exception as exc:

--- a/myplots/templatetags/photometry_settings.py
+++ b/myplots/templatetags/photometry_settings.py
@@ -4,18 +4,18 @@ import pandas as pd
 from astropy.time import Time
 import plotly.graph_objects as go
 
-from .utils import find_target_name, is_site_up
+from .utils import find_target_name
 from lasair import lasair_client
 from tidestom.settings import BROKERS
 lasair_ztf_token = BROKERS['LASAIR']['ztf_api_key']
-lasair_ztf_url = "https://lasair-ztf.lsst.ac.uk"
+lasair_ztf_url = BROKERS['LASAIR']['ztf_url']
 lasair_lsst_token = BROKERS['LASAIR']['lsst_api_key']
-lasair_lsst_url = "https://lasair-lsst.lsst.ac.uk"
+lasair_lsst_url = BROKERS['LASAIR']['lsst_url']
 
 ##########
 # Lasair #
 ##########
-def fetch_target_lasair(ra: float, dec: float, survey: str = None) -> pd.DataFrame:
+def fetch_target_lasair(ra: float, dec: float, survey: str) -> pd.DataFrame:
     """
     Fetches the light curve of a target from the Lasair broker.
     
@@ -31,53 +31,69 @@ def fetch_target_lasair(ra: float, dec: float, survey: str = None) -> pd.DataFra
     """
     assert survey in ["ztf", "lsst"], "Not a valid survey - either ztf or lsst"
     if survey == "ztf":
-        url, token = lasair_ztf_url, lasair_ztf_token
-        filter_dict = {1: 'ztf_g', 2: 'ztf_r', 3: 'ztf_i'}
+        url, token = lasair_ztf_url, lasair_ztf_token 
     else:
         url, token = lasair_lsst_url, lasair_lsst_token
-        filter_dict = {1: 'lsst_u', 2: 'lsst_g', 3: 'lsst_r',
-                       4: 'lsst_i', 5: 'lsst_z', 6: 'lsst_y',
-                       }
+        
     # get name of target
     target_name = find_target_name(ra, dec, survey)
     if target_name is None:
         return None
         
-    # query photometry from Lasair
-    if not is_site_up(url):
-        return None
     lasair = lasair_client(token, endpoint = url + "/api")
-    target_info = lasair.lightcurves([target_name])
-    phot_list = target_info[0]['candidates']
-    det_list = []  # detections
-    nondet_list = []  # non-detections
-    # convert to dataframe
-    for phot_dict in phot_list:
-        # convert values into list to convert to dataframe
-        phot_dict = {key:[value] for key, value in phot_dict.items()}
-        df = pd.DataFrame(phot_dict)
-        if 'magpsf' in phot_dict.keys():
-            det_list.append(df)
-        else:
-            nondet_list.append(df)
-    with warnings.catch_warnings():
-        # ignore annoying pandas future warning
-        warnings.simplefilter("ignore")
-        det_df = pd.concat(det_list)
-        nondet_df = pd.concat(nondet_list)
-    phot_df = pd.concat([det_df, nondet_df])  # for non detection use diffmaglim
-    jds = Time(phot_df['jd'].values, format='jd')
-    phot_df['mjd'] = jds.mjd
+    ### ZTF ###
+    if survey == "ztf":
+        result = lasair.object(target_name, lasair_added=False, lite=True)
+        phot_list = result['candidates']
+        det_list = []  # detections
+        nondet_list = []  # non-detections
+        # convert to dataframe
+        for phot_dict in phot_list:
+            # convert values into list to convert to dataframe
+            phot_dict = {key:[value] for key, value in phot_dict.items()}
+            df = pd.DataFrame(phot_dict)
+            if 'magpsf' in phot_dict.keys():
+                det_list.append(df)
+            else:
+                nondet_list.append(df)
+        with warnings.catch_warnings():
+            # ignore annoying pandas future warning
+            warnings.simplefilter("ignore")
+            det_df = pd.concat(det_list)
+            nondet_df = pd.concat(nondet_list)
+        phot_df = pd.concat([det_df, nondet_df])  # for non detection use diffmaglim
+        jds = Time(phot_df['jd'].values, format='jd')
+        phot_df['mjd'] = jds.mjd
+        # Replace photometric filter numbers with human-readable names
+        filter_dict = {1: 'ztf_g', 2: 'ztf_r', 3: 'ztf_i'}
+        phot_df['fid'] = [filter_dict[fid] for fid in phot_df['fid']]
+        # rename columns
+        phot_df.rename(columns={'fid':'filter', 
+                               'magpsf':'mag', 
+                               'sigmapsf':'mag_err',
+                               'diffmaglim':'upper_mag'
+                              }, 
+                      inplace=True)
+    ### LSST ###
+    else:
+        result = lasair.object(target_name, lasair_added=False, lite=True)
+        phot_df = pd.DataFrame(result["diaSourcesList"]).set_index("diaSourceId")
+        #['midpointMjdTai', 'band', 'psfFlux', 'psfFluxErr', 'reliability']
+        zp = 31.4  # LSST zeropoint as the flux is in nano-Jansky
+        #phot_df.loc[phot_df["psfFlux"] < 1, "psfFlux"] = 1
+        phot_df["mag"] = -2.5 * np.log10(phot_df.psfFlux.values) + zp
+        phot_df["mag_err"] = (2.5 / np.log(10)) * (phot_df.psfFluxErr.values / phot_df.psfFlux.values)
+        # 3-sigma upper limits, as in https://fallingstar-data.com/forcedphot/resultdesc/
+        snr = phot_df.psfFlux.values / phot_df.psfFluxErr.values
+        upper_mag = -2.5 * np.log10(3 * phot_df.psfFluxErr.values) + zp
+        phot_df["upper_mag"] = np.where(snr < 3, upper_mag, np.nan)
+        phot_df["mag"] = np.where(~phot_df.upper_mag.isna(), np.nan, phot_df.mag.values)
+        phot_df["band"] = "lsst_" + phot_df["band"].astype(str)  # rename bands
+        phot_df.rename(columns={'midpointMjdTai':'mjd', 
+                               'band':'filter', 
+                              }, 
+                      inplace=True)
     
-    # rename columns
-    phot_df.rename(columns={'fid':'filter', 
-                           'magpsf':'mag', 
-                           'sigmapsf':'mag_err',
-                           'diffmaglim':'upper_mag'
-                          }, 
-                  inplace=True)
-    # Replace photometric filter numbers with human-readable names
-    phot_df['filter'] = [filter_dict[fid] for fid in phot_df['filter']]
     # Sort the table on filter and time:
     phot_df.sort_values(['filter', 'mjd'], inplace=True)
     phot_df = phot_df[['filter', 'mjd', 'mag', 'mag_err', 'upper_mag']]

--- a/myplots/templatetags/utils.py
+++ b/myplots/templatetags/utils.py
@@ -4,9 +4,9 @@ import numpy as np
 from lasair import lasair_client
 from tidestom.settings import BROKERS
 lasair_ztf_token = BROKERS['LASAIR']['ztf_api_key']
-lasair_ztf_url = "https://lasair-ztf.lsst.ac.uk"
+lasair_ztf_url = BROKERS['LASAIR']['ztf_url']
 lasair_lsst_token = BROKERS['LASAIR']['lsst_api_key']
-lasair_lsst_url = "https://lasair-lsst.lsst.ac.uk"
+lasair_lsst_url = BROKERS['LASAIR']['lsst_url']
 
 ##########
 # Lasair #

--- a/tidestom/settings.py
+++ b/tidestom/settings.py
@@ -350,7 +350,9 @@ BROKERS = {
     },
     'LASAIR': {
         'ztf_api_key': os.environ.get('LASAIR_ZTF_KEY'),
+        'ztf_url': "https://lasair-ztf.lsst.ac.uk",
         'lsst_api_key': os.environ.get('LASAIR_LSST_KEY'),
+        'lsst_url': "https://lasair.lsst.ac.uk",
     }
 }
 


### PR DESCRIPTION
This PR fixes the Lasair-LSST API to retrieve photoemtry and target name. The ZTF API was also updates and the Lasair client now works similarly for both surveys, starting from either version 0.1.3 or 0.1.4 (currently the latest).